### PR TITLE
Integrate Jira API and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 # Excel reports and data
 *.xlsx
 jira_stories.csv
+jira_token.json
 
 # IDE directories
 .vscode/

--- a/README.md
+++ b/README.md
@@ -101,4 +101,10 @@ Additional options:
 - `--config` path to configuration JSON.
 - adjust `commit_fetch_limit` in `config.json` to fetch more commits per page.
 
-The script outputs an Excel report `gitxjira_report_<timestamp>.xlsx` with Jira stories, commit details, and any stories missing from Git.
+The script outputs an Excel report `gitxjira_report_<timestamp>.xlsx` with Jira stories, commit details, and any stories missing from Git. In the "Missing Jira Stories" worksheet the **Status** column appears immediately after **App** so you can quickly see the state of each issue.
+
+## Troubleshooting
+
+* **401/403 errors from Jira** – The access token may have expired. Regenerate `jira_token.json` using the **One-Time Token Setup** steps.
+* **SSL certificate failures** – Ensure you installed the certificate bundle or set `REQUESTS_CA_BUNDLE` to your internal certificate authority file.
+* **No stories returned** – Verify the `fix_version` in `config.json` matches the release in Jira and that your account has permission to read those issues.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Git vs Jira Excel Report
+# Git vs Jira Release Audit
 
-This tool compares Jira issues exported to Excel against Bitbucket commit history.
+This tool compares Jira issues retrieved from the Jira Cloud REST API against Bitbucket commit history.
 
 ## Getting Started
 
@@ -39,50 +39,58 @@ This tool compares Jira issues exported to Excel against Bitbucket commit histor
 6. Optionally adjust `config.json` to list repositories and branches.
 7. `commit_fetch_limit` in `config.json` controls how many commits are fetched per API page (default 100).
 
+### ✅ Jira OAuth Setup
+
+1. Visit <https://developer.atlassian.com/console/myapps>
+2. Register a **3LO OAuth App** (Authorization Code Grant)
+3. Set Redirect URL: `http://localhost:8080/callback`
+4. Save the Client ID and Client Secret
+
+### 🚀 One-Time Token Setup
+
+1. Open this browser URL (replace `YOUR_CLIENT_ID`):
+
+   <https://auth.atlassian.com/authorize?audience=api.atlassian.com&client_id=YOUR_CLIENT_ID&scope=read:jira-user%20read:jira-work%20write:jira-work%20offline_access&redirect_uri=http://localhost:8080/callback&state=xyz123&response_type=code&prompt=consent>
+
+2. Approve the app and copy the `code` from the URL
+3. Run `write_jira_token.py` with your:
+   - Client ID
+   - Client Secret
+   - Authorization Code
+
+4. This generates `jira_token.json` and stores it locally.
+
+> 🛡️ **Important**: Do not commit `jira_token.json`. It contains sensitive credentials. It is ignored by `.gitignore`.
+
+#### 🔁 If Token Expires
+
+If `refresh_token` is older than 30 days or fails:
+- Repeat the above process to get a new `code` and generate a new `jira_token.json`
+
 ## Usage
 
-Export issues from Jira as an Excel file (`.xlsx`) or CSV file containing columns such as *Issue key*, *Summary*, *Issue type*, *Components*, and *Fix version(s)*.
+Jira stories are fetched automatically using the fix version defined in `config.json`.
 
 Run the tool (Windows):
 
 ```bat
-run_gitxjira.bat --jira-excel path/to/jira.xlsx
-```
-
-For a guided experience that lets you pick the Jira file and run mode:
-
-Windows:
-```bat
 run_release_audit.bat
-```
-
-macOS/Linux:
-```bash
-./run_gitxjira.command
 ```
 
 Or directly with Python:
 
 ```bash
-python main.py --jira-excel path/to/jira.xlsx
+python main.py
 ```
+
 Only process the release branch:
 ```bash
-python main.py --jira-excel path/to/jira.xlsx --release-only
+python main.py --release-only
 ```
 Only process the develop branch:
 ```bash
-python main.py --jira-excel path/to/jira.xlsx --develop-only
+python main.py --develop-only
 ```
-CSV files can be provided in the same way:
-```bash
-python main.py --jira-excel path/to/jira.csv
-```
-If your file name contains spaces, wrap it in quotes:
-```bash
-python main.py --jira-excel "Release Audit.csv"
-```
-Ensure you run `main.py` as the script (the `.csv` file should be passed with `--jira-excel`).
 
 Additional options:
 

--- a/excel_writer.py
+++ b/excel_writer.py
@@ -24,8 +24,13 @@ def write_excel(all_commits, missing_stories_data, output_file):
             )
 
         if missing_stories_data:
-            pd.DataFrame(missing_stories_data).to_excel(
-                writer, sheet_name="Missing Jira Stories", index=False
-            )
+            df = pd.DataFrame(missing_stories_data)
+            if "Status" in df.columns and "App" in df.columns:
+                cols = df.columns.tolist()
+                cols.remove("Status")
+                app_index = cols.index("App")
+                cols.insert(app_index + 1, "Status")
+                df = df[cols]
+            df.to_excel(writer, sheet_name="Missing Jira Stories", index=False)
         else:
             logger.info("No missing Jira stories found or no commits fetched to compare.")

--- a/jira_client.py
+++ b/jira_client.py
@@ -51,7 +51,7 @@ def load_jira_issues(fix_version: str, token_file: str = "jira_token.json") -> d
             "jql": jql,
             "startAt": start_at,
             "maxResults": max_results,
-            "fields": "summary,issuetype,fixVersions,components",
+            "fields": "summary,issuetype,fixVersions,components,status",
         }
         response = requests.get(f"{JIRA_API_BASE}/search", headers=headers, params=params)
         response.raise_for_status()
@@ -71,6 +71,7 @@ def load_jira_issues(fix_version: str, token_file: str = "jira_token.json") -> d
             "IssueType": fields.get("issuetype", {}).get("name", ""),
             "Summary": fields.get("summary", ""),
             "App": ", ".join(c.get("name", "") for c in fields.get("components", [])),
+            "Status": fields.get("status", {}).get("name", ""),
             "FixVersion": ", ".join(v.get("name", "") for v in fields.get("fixVersions", [])),
             "Link": f"{jira_base.rstrip('/')}/{key}",
         }

--- a/jira_client.py
+++ b/jira_client.py
@@ -1,8 +1,12 @@
 import requests
+import os
+import logging
 from jira_token_manager import get_valid_access_token
 
 CLOUD_ID = "aaf3ee41-766b-44b8-8b12-92b0e035861f"
 JIRA_API_BASE = f"https://api.atlassian.com/ex/jira/{CLOUD_ID}/rest/api/3"
+
+logger = logging.getLogger(__name__)
 
 def fetch_issues_by_jql(jql, token_file="jira_token.json", max_results=100):
     token = get_valid_access_token(token_file)
@@ -21,3 +25,55 @@ def fetch_issues_by_jql(jql, token_file="jira_token.json", max_results=100):
     )
     response.raise_for_status()
     return response.json()["issues"]
+
+
+def load_jira_issues(fix_version: str, token_file: str = "jira_token.json") -> dict:
+    """Load Jira issues for the given fix version via the Jira Cloud REST API."""
+    jql = (
+        f'fixVersion = "{fix_version}" '
+        'AND issuetype not in ('
+        '"Sub-task", "Tech Story", "Epic", "Test Execution", '
+        '"Dev Task", "QA Task", "Shoulder Check", "Automation ", '
+        '"Test Plan", "Spike", "Test")'
+    )
+
+    token = get_valid_access_token(token_file)
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+
+    all_issues = []
+    start_at = 0
+    max_results = 100
+    while True:
+        params = {
+            "jql": jql,
+            "startAt": start_at,
+            "maxResults": max_results,
+            "fields": "summary,issuetype,fixVersions,components",
+        }
+        response = requests.get(f"{JIRA_API_BASE}/search", headers=headers, params=params)
+        response.raise_for_status()
+        data = response.json()
+        all_issues.extend(data.get("issues", []))
+        if start_at + max_results >= data.get("total", 0):
+            break
+        start_at += max_results
+
+    jira_base = os.getenv("JIRA_BASE_URL", "https://csaaig.atlassian.net/browse")
+    stories = {}
+    for issue in all_issues:
+        key = issue.get("key", "").upper()
+        fields = issue.get("fields", {})
+        stories[key] = {
+            "Jira Story": key,
+            "IssueType": fields.get("issuetype", {}).get("name", ""),
+            "Summary": fields.get("summary", ""),
+            "App": ", ".join(c.get("name", "") for c in fields.get("components", [])),
+            "FixVersion": ", ".join(v.get("name", "") for v in fields.get("fixVersions", [])),
+            "Link": f"{jira_base.rstrip('/')}/{key}",
+        }
+
+    logger.info("Loaded %d Jira stories via API", len(stories))
+    return stories

--- a/run_release_audit.bat
+++ b/run_release_audit.bat
@@ -5,36 +5,13 @@ rem Determine the directory of this script to allow relative execution
 set SCRIPT_DIR=%~dp0
 pushd %SCRIPT_DIR%
 
-set IDX=0
-for %%f in (*.csv *.xlsx) do (
-    set /a IDX+=1
-    set "FILE!IDX!=%%~f"
-    echo   !IDX!. %%~f
-)
-
-if %IDX%==0 (
-    echo No .csv or .xlsx files found in %CD%.
-)
-
-set /p CHOICE=Enter the number of the file to use, or press Enter to manually input a file path: 
-if "%CHOICE%"=="" (
-    set /p FILEPATH=Enter the path to the Jira file: 
-) else (
-    set FILEPATH=!FILE%CHOICE%!
-    if "!FILEPATH!"=="" (
-        echo Invalid choice. Please provide a file path manually.
-        set /p FILEPATH=Enter the path to the Jira file: 
-    )
-)
-
 set MODE_ARG=
-
 
 echo Choose run mode:
 echo   1. Full run (release + develop)
 echo   2. Develop only
 echo   3. Release only
-set /p MODE=Enter 1, 2, or 3: 
+set /p MODE=Enter 1, 2, or 3:
 if "%MODE%"=="2" (
     set MODE_ARG=--develop-only
 ) else if "%MODE%"=="3" (
@@ -42,8 +19,8 @@ if "%MODE%"=="2" (
 )
 
 echo Running:
-echo python %SCRIPT_DIR%main.py --jira-excel "!FILEPATH!" !MODE_ARG!
-python "%SCRIPT_DIR%main.py" --jira-excel "!FILEPATH!" !MODE_ARG!
+echo python %SCRIPT_DIR%main.py !MODE_ARG!
+python "%SCRIPT_DIR%main.py" !MODE_ARG!
 
 popd
 pause


### PR DESCRIPTION
## Summary
- load Jira stories via the Jira Cloud REST API
- auto-refresh tokens via `jira_token_manager`
- drop Excel input paths from the code and batch file
- ignore `jira_token.json`
- document OAuth token setup and new usage in README

## Testing
- `python -m py_compile main.py jira_client.py jira_token_manager.py bitbucket_api.py commit_processor.py config_loader.py excel_writer.py excel_loader.py`
- `pip install -r requirements.txt`
- `python main.py --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_68825409adc8832fa1932d47b40ca4ed