### PR TITLE
Add tkinter OAuth GUI token generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,14 @@ jira_token.json
 .vscode/
 .idea/
 
+build/gui_token_setup/Analysis-00.toc
+build/gui_token_setup/EXE-00.toc
+build/gui_token_setup/base_library.zip
+build/gui_token_setup/gui_token_setup.pkg
+build/gui_token_setup/PKG-00.toc
+build/gui_token_setup/PYZ-00.pyz
+build/gui_token_setup/PYZ-00.toc
+build/gui_token_setup/warn-gui_token_setup.txt
+build/gui_token_setup/xref-gui_token_setup.html
+/dist
+gui_token_setup.spec

--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ This tool compares Jira issues retrieved from the Jira Cloud REST API against Bi
 
 > 🛡️ **Important**: Do not commit `jira_token.json`. It contains sensitive credentials. It is ignored by `.gitignore`.
 
+### 🖥️ GUI Token Setup
+
+Instead of manually copying the authorization code, you can run a small GUI helper located in `token_generator/`:
+
+```bash
+python token_generator/gui_token_setup.py
+```
+
+Follow the prompts to enter your *Client ID* and *Client Secret*. The tool launches your browser for approval and saves `jira_token.json` automatically. To build a standalone executable use:
+
+```bash
+pyinstaller --onefile token_generator/gui_token_setup.py
+```
+
+
 #### 🔁 If Token Expires
 
 If `refresh_token` is older than 30 days or fails:

--- a/token_generator/flask_listener.py
+++ b/token_generator/flask_listener.py
@@ -1,0 +1,41 @@
+import threading
+from urllib.parse import urlparse
+
+from flask import Flask, request
+from werkzeug.serving import make_server
+
+
+class AuthorizationCodeReceiver:
+    """Simple local server to capture OAuth authorization code."""
+
+    def __init__(self, redirect_uri: str):
+        parsed = urlparse(redirect_uri)
+        self.port = parsed.port or 80
+        self.path = parsed.path or "/"
+        self.code = None
+        self._event = threading.Event()
+        self.app = Flask(__name__)
+
+        @self.app.route(self.path)
+        def _callback():
+            code = request.args.get("code")
+            if not code:
+                return "Authorization code missing", 400
+            self.code = code
+            self._event.set()
+            shutdown = request.environ.get("werkzeug.server.shutdown")
+            if shutdown:
+                shutdown()
+            return "Authorization received. You may close this window."
+
+    def start(self) -> None:
+        """Start the local server."""
+        self.server = make_server("localhost", self.port, self.app)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    def wait_for_code(self, timeout: int = 300) -> str | None:
+        """Wait for the authorization code or timeout."""
+        if not self._event.wait(timeout):
+            return None
+        return self.code

--- a/token_generator/gui_token_setup.py
+++ b/token_generator/gui_token_setup.py
@@ -1,0 +1,95 @@
+import json
+import logging
+import threading
+import webbrowser
+from pathlib import Path
+from tkinter import Tk, ttk, messagebox, StringVar
+from urllib.parse import urlencode, quote_plus
+
+import requests
+
+from flask_listener import AuthorizationCodeReceiver
+from oauth_client import exchange_code_for_token
+
+logging.basicConfig(level=logging.INFO)
+
+
+class TokenGeneratorGUI:
+    def __init__(self, root: Tk) -> None:
+        self.root = root
+        root.title("Jira OAuth Token Generator")
+
+        self.client_id_var = StringVar()
+        self.client_secret_var = StringVar()
+        self.redirect_var = StringVar(value="http://localhost:8080/callback")
+
+        ttk.Label(root, text="Client ID:").grid(row=0, column=0, sticky="e", pady=5, padx=5)
+        ttk.Entry(root, textvariable=self.client_id_var, width=40).grid(row=0, column=1, pady=5, padx=5)
+
+        ttk.Label(root, text="Client Secret:").grid(row=1, column=0, sticky="e", pady=5, padx=5)
+        ttk.Entry(root, textvariable=self.client_secret_var, show="*", width=40).grid(row=1, column=1, pady=5, padx=5)
+
+        ttk.Label(root, text="Redirect URI:").grid(row=2, column=0, sticky="e", pady=5, padx=5)
+        ttk.Entry(root, textvariable=self.redirect_var, width=40).grid(row=2, column=1, pady=5, padx=5)
+
+        ttk.Button(root, text="Launch Authorization", command=self.launch).grid(row=3, column=0, columnspan=2, pady=10)
+
+    def launch(self) -> None:
+        threading.Thread(target=self._auth_flow, daemon=True).start()
+
+    def _auth_flow(self) -> None:
+        client_id = self.client_id_var.get().strip()
+        client_secret = self.client_secret_var.get().strip()
+        redirect_uri = self.redirect_var.get().strip()
+
+        if not client_id or not client_secret:
+            messagebox.showerror("Input Error", "Client ID and Client Secret are required")
+            return
+
+        receiver = AuthorizationCodeReceiver(redirect_uri)
+        try:
+            receiver.start()
+        except OSError:
+            messagebox.showerror("Port In Use", f"Cannot start local server on port {receiver.port}")
+            return
+
+        params = {
+            "audience": "api.atlassian.com",
+            "client_id": client_id,
+            "scope": "read:jira-user read:jira-work write:jira-work offline_access",
+            "redirect_uri": redirect_uri,
+            "state": "xyz123",
+            "response_type": "code",
+            "prompt": "consent",
+        }
+        url = "https://auth.atlassian.com/authorize?" + urlencode(params, quote_via=quote_plus)
+        webbrowser.open(url)
+
+        code = receiver.wait_for_code()
+        if not code:
+            messagebox.showerror("Timeout", "No authorization code received")
+            return
+
+        try:
+            token_data = exchange_code_for_token(client_id, client_secret, code, redirect_uri)
+        except requests.HTTPError as exc:
+            logging.exception("Token exchange failed")
+            messagebox.showerror("Error", f"Token request failed: {exc.response.text}")
+            return
+        except Exception as exc:
+            logging.exception("Token exchange failed")
+            messagebox.showerror("Error", str(exc))
+            return
+
+        Path("jira_token.json").write_text(json.dumps(token_data, indent=2), encoding="utf-8")
+        messagebox.showinfo("Success", "Token saved to jira_token.json")
+
+
+def main() -> None:
+    root = Tk()
+    TokenGeneratorGUI(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/token_generator/oauth_client.py
+++ b/token_generator/oauth_client.py
@@ -1,0 +1,25 @@
+import json
+from datetime import datetime, timezone
+from typing import Dict
+
+import requests
+
+TOKEN_URL = "https://auth.atlassian.com/oauth/token"
+
+
+def exchange_code_for_token(client_id: str, client_secret: str, code: str, redirect_uri: str) -> Dict:
+    """Exchange an authorization code for OAuth tokens."""
+    payload = {
+        "grant_type": "authorization_code",
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "code": code,
+        "redirect_uri": redirect_uri,
+    }
+    response = requests.post(TOKEN_URL, json=payload, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    data["client_id"] = client_id
+    data["client_secret"] = client_secret
+    data["token_created_at"] = datetime.now(timezone.utc).isoformat()
+    return data

--- a/token_generator/requirements.txt
+++ b/token_generator/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/token_generator/requirements.txt
+++ b/token_generator/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 requests
+pyinstaller


### PR DESCRIPTION
## Summary
- implement a tkinter GUI that walks through Atlassian OAuth
- open a local Flask listener to capture the authorization code
- exchange code for tokens and save `jira_token.json`
- document running the GUI tool and PyInstaller usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python token_generator/gui_token_setup.py --help` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_688c31c256cc832fbc046519400a8c26