### PR TITLE
Discover Jira cloud ID dynamically and add Bitbucket diagnostics

### DIFF
--- a/bitbucket_api.py
+++ b/bitbucket_api.py
@@ -1,6 +1,7 @@
 import requests
 import logging
 from datetime import datetime
+from urllib.parse import urlparse
 
 DEFAULT_FETCH_LIMIT = 100  # maximum commits per page supported by API
 
@@ -50,6 +51,27 @@ def fetch_commits(
         paginated_url = f"{commits_url}&start={start}&limit={limit}"
         try:
             response = requests.get(paginated_url, auth=bitbucket_auth, headers=bitbucket_headers, params=params)
+            if response.status_code in (401, 403, 404):
+                parsed = urlparse(bitbucket_base_url)
+                api_hint = (
+                    f"{parsed.scheme}://{parsed.netloc}{parsed.path}".rstrip("/")
+                    if parsed.scheme and parsed.netloc
+                    else bitbucket_base_url.rstrip("/")
+                )
+                if response.status_code == 404:
+                    logger.warning(
+                        "Bitbucket returned 404 for %s. Verify VPN/connectivity and confirm the REST base URL "
+                        "(expected .../rest/api/1.0 or .../rest/api/latest, without duplicating the path). "
+                        "Current base: %s",
+                        commits_url,
+                        api_hint,
+                    )
+                else:
+                    logger.warning(
+                        "Bitbucket returned %s for %s. Verify credentials and connectivity.",
+                        response.status_code,
+                        commits_url,
+                    )
             response.raise_for_status()
             commits = response.json()
             values = commits.get("values", [])

--- a/jira_client.py
+++ b/jira_client.py
@@ -3,57 +3,118 @@ import os
 import logging
 from jira_token_manager import get_valid_access_token
 
-CLOUD_ID = "aaf3ee41-766b-44b8-8b12-92b0e035861f"
-JIRA_API_BASE = f"https://api.atlassian.com/ex/jira/{CLOUD_ID}/rest/api/3"
+ACCESSIBLE_RESOURCES_URL = "https://api.atlassian.com/oauth/token/accessible-resources"
+DEFAULT_JIRA_SITE_URL = "https://csaaig.atlassian.net"
 
 logger = logging.getLogger(__name__)
 
+
+def discover_cloud_id(token: str, jira_site_url: str) -> str:
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+    response = requests.get(ACCESSIBLE_RESOURCES_URL, headers=headers)
+    response.raise_for_status()
+    resources = response.json()
+    normalized_url = jira_site_url.rstrip("/")
+    for resource in resources:
+        if resource.get("url", "").rstrip("/") == normalized_url:
+            return resource["id"]
+    for resource in resources:
+        scopes = resource.get("scopes", [])
+        if any("jira" in scope for scope in scopes):
+            return resource["id"]
+    raise RuntimeError(f"No Jira site found for url {jira_site_url}")
+
+
+def build_jira_api_base(cloud_id: str) -> str:
+    return f"https://api.atlassian.com/ex/jira/{cloud_id}/rest/api/3"
+
+
 def fetch_issues_by_jql(jql, token_file="jira_token.json", max_results=100):
     token = get_valid_access_token(token_file)
+    jira_site_url = os.getenv("JIRA_SITE_URL", DEFAULT_JIRA_SITE_URL)
+    cloud_id = discover_cloud_id(token, jira_site_url)
+    jira_api_base = build_jira_api_base(cloud_id)
     headers = {
         "Authorization": f"Bearer {token}",
-        "Accept": "application/json"
+        "Accept": "application/json",
     }
     response = requests.get(
-        f"{JIRA_API_BASE}/search",
+        f"{jira_api_base}/search",
         headers=headers,
         params={
             "jql": jql,
             "maxResults": max_results,
-            "fields": "key,summary,issuetype,fixVersions"
-        }
+            "fields": "key,summary,issuetype,fixVersions",
+        },
     )
+    if response.status_code in (401, 410):
+        token = get_valid_access_token(token_file)
+        if response.status_code == 410:
+            cloud_id = discover_cloud_id(token, jira_site_url)
+            jira_api_base = build_jira_api_base(cloud_id)
+        headers["Authorization"] = f"Bearer {token}"
+        response = requests.get(
+            f"{jira_api_base}/search",
+            headers=headers,
+            params={
+                "jql": jql,
+                "maxResults": max_results,
+                "fields": "key,summary,issuetype,fixVersions",
+            },
+        )
     response.raise_for_status()
     return response.json()["issues"]
 
 
 def load_jira_issues(fix_version: str, token_file: str = "jira_token.json") -> dict:
     """Load Jira issues for the given fix version via the Jira Cloud REST API."""
-    jql = (
-        f'fixVersion = "{fix_version}" '
-        'AND issuetype not in ('
-        '"Sub-task", "Tech Story", "Epic", "Test Execution", '
-        '"Dev Task", "QA Task", "Shoulder Check", "Automation ", '
-        '"Test Plan", "Spike", "Test")'
-    )
+    excluded_issue_types = [
+        "Sub-task",
+        "Tech Story",
+        "Epic",
+        "Test Execution",
+        "Dev Task",
+        "QA Task",
+        "Shoulder Check",
+        "Automation",
+        "Test Plan",
+        "Spike",
+        "Test",
+    ]
+    issue_list = ", ".join(f'"{issue_type.strip()}"' for issue_type in excluded_issue_types)
+    jql = f'fixVersion = "{fix_version}" AND issuetype not in ({issue_list})'
 
     token = get_valid_access_token(token_file)
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/json",
-    }
+    jira_site_url = os.getenv("JIRA_SITE_URL", DEFAULT_JIRA_SITE_URL)
+    cloud_id = discover_cloud_id(token, jira_site_url)
+    jira_api_base = build_jira_api_base(cloud_id)
 
     all_issues = []
     start_at = 0
     max_results = 100
     while True:
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+        }
         params = {
             "jql": jql,
             "startAt": start_at,
             "maxResults": max_results,
             "fields": "summary,issuetype,fixVersions,components,status",
         }
-        response = requests.get(f"{JIRA_API_BASE}/search", headers=headers, params=params)
+        response = requests.get(f"{jira_api_base}/search", headers=headers, params=params)
+        if response.status_code in (401, 410):
+            token = get_valid_access_token(token_file)
+            if response.status_code == 410:
+                cloud_id = discover_cloud_id(token, jira_site_url)
+                jira_api_base = build_jira_api_base(cloud_id)
+            headers["Authorization"] = f"Bearer {token}"
+            response = requests.get(
+                f"{jira_api_base}/search",
+                headers=headers,
+                params=params,
+            )
         response.raise_for_status()
         data = response.json()
         all_issues.extend(data.get("issues", []))


### PR DESCRIPTION
### Motivation
- Remove a hardcoded Jira cloud id and make Jira API calls work across Jira Cloud instances by discovering the cloud id at runtime.
- Handle expired/rotated OAuth tokens and Jira site re-association by retrying searches on 401/410 with token refresh and re-discovery.
- Improve Bitbucket failure messaging to help diagnose connectivity, credentials, and REST base-URL misconfiguration.

### Description
- Add `discover_cloud_id` and `build_jira_api_base` helpers and use `https://api.atlassian.com/oauth/token/accessible-resources` to map a token to a cloud id, using `JIRA_SITE_URL` (with a default) for matching. 
- Replace hardcoded JIRA API base with dynamic `jira_api_base` in `fetch_issues_by_jql` and `load_jira_issues`, and retry on 401/410 by refreshing the token and re-discovering the cloud id when needed.
- Normalize and construct the excluded issue types list programmatically and build the JQL string dynamically.
- Add Bitbucket diagnostics in `fetch_commits` to log helpful warnings (including a base-URL hint) when responses return 401/403/404, and import `urlparse` to help format the hint.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982386564f4832f8f940d8fa327b967)