### PR TITLE
Dynamic Jira cloud discovery and Bitbucket API base fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ This tool compares Jira issues retrieved from the Jira Cloud REST API against Bi
    ```
 
    Use `--redirect-uri` if you specified a custom redirect during the OAuth
-   setup.
+   setup. The redirect URI must **exactly** match what you registered in the
+   Atlassian app (including scheme and port). Authorization codes are short
+   lived and single-use, so re-run the browser authorization if you see a
+   400 error from `https://auth.atlassian.com/oauth/token`.
 
 4. The script writes `jira_token.json` locally next to your source files.
 

--- a/bitbucket_api.py
+++ b/bitbucket_api.py
@@ -1,10 +1,51 @@
-import requests
 import logging
 from datetime import datetime
+import requests
 
 DEFAULT_FETCH_LIMIT = 100  # maximum commits per page supported by API
 
 logger = logging.getLogger(__name__)
+
+
+def _build_api_base(base_url: str, api_version: str) -> str:
+    trimmed = base_url.rstrip("/")
+    if "/rest/api/" in trimmed:
+        trimmed = trimmed.split("/rest/api/")[0]
+    return f"{trimmed}/rest/api/{api_version}"
+
+
+def resolve_bitbucket_base_url(bitbucket_base_url, bitbucket_auth, bitbucket_headers):
+    candidates = [
+        _build_api_base(bitbucket_base_url, "1.0"),
+        _build_api_base(bitbucket_base_url, "latest"),
+    ]
+    for candidate in candidates:
+        try:
+            response = requests.get(
+                f"{candidate}/projects",
+                auth=bitbucket_auth,
+                headers=bitbucket_headers,
+                params={"limit": 1},
+                timeout=10,
+            )
+            if response.ok:
+                if candidate != bitbucket_base_url:
+                    logger.info("Using Bitbucket API base URL %s", candidate)
+                return candidate
+            logger.warning(
+                "Bitbucket API base URL %s returned %s. Response: %s",
+                candidate,
+                response.status_code,
+                response.text[:200],
+            )
+        except requests.exceptions.RequestException as exc:
+            logger.warning(
+                "Bitbucket API base URL %s is unreachable. Check VPN/SSO or URL. Error: %s",
+                candidate,
+                exc,
+            )
+    return bitbucket_base_url
+
 
 def fetch_commits(
     bitbucket_base_url,

--- a/jira_client.py
+++ b/jira_client.py
@@ -66,7 +66,7 @@ def fetch_issues_by_jql(jql, token_file="jira_token.json", max_results=100):
         "Accept": "application/json",
     }
     response = requests.get(
-        f"{jira_api_base}/search",
+        f"{jira_api_base}/search/jql",
         headers=headers,
         params={
             "jql": jql,
@@ -122,7 +122,7 @@ def load_jira_issues(fix_version: str, token_file: str = "jira_token.json") -> d
                     "fields": "summary,issuetype,fixVersions,components,status",
                 }
                 response = requests.get(
-                    f"{jira_api_base}/search", headers=headers, params=params
+                    f"{jira_api_base}/search/jql", headers=headers, params=params
                 )
                 response.raise_for_status()
                 data = response.json()

--- a/jira_client.py
+++ b/jira_client.py
@@ -1,27 +1,78 @@
-import requests
-import os
 import logging
+import os
+from typing import Iterable, Optional
+
+import requests
+
 from jira_token_manager import get_valid_access_token
 
-CLOUD_ID = "aaf3ee41-766b-44b8-8b12-92b0e035861f"
-JIRA_API_BASE = f"https://api.atlassian.com/ex/jira/{CLOUD_ID}/rest/api/3"
+ACCESSIBLE_RESOURCES_URL = "https://api.atlassian.com/oauth/token/accessible-resources"
+JIRA_API_ROOT = "https://api.atlassian.com/ex/jira"
 
 logger = logging.getLogger(__name__)
 
+
+def _normalize_site_url(site_url: Optional[str]) -> Optional[str]:
+    if not site_url:
+        return None
+    normalized = site_url.rstrip("/")
+    if normalized.endswith("/browse"):
+        normalized = normalized[: -len("/browse")]
+    return normalized
+
+
+def get_accessible_resources(token: str) -> Iterable[dict]:
+    response = requests.get(
+        ACCESSIBLE_RESOURCES_URL,
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def resolve_cloud_id(token: str, site_url: Optional[str] = None) -> str:
+    normalized_site_url = _normalize_site_url(site_url)
+    resources = list(get_accessible_resources(token))
+    if not resources:
+        raise RuntimeError("No accessible Jira resources found for this token.")
+
+    if normalized_site_url:
+        for resource in resources:
+            resource_url = _normalize_site_url(resource.get("url"))
+            if resource_url == normalized_site_url:
+                return resource["id"]
+
+    if len(resources) == 1:
+        return resources[0]["id"]
+
+    available = ", ".join(resource.get("url", "unknown") for resource in resources)
+    raise RuntimeError(
+        "Multiple Jira sites available. Set JIRA_SITE_URL to select the correct site. "
+        f"Available sites: {available}"
+    )
+
+
+def build_jira_api_base(cloud_id: str) -> str:
+    return f"{JIRA_API_ROOT}/{cloud_id}/rest/api/3"
+
+
 def fetch_issues_by_jql(jql, token_file="jira_token.json", max_results=100):
     token = get_valid_access_token(token_file)
+    site_url = os.getenv("JIRA_SITE_URL") or os.getenv("JIRA_BASE_URL")
+    cloud_id = resolve_cloud_id(token, site_url=site_url)
+    jira_api_base = build_jira_api_base(cloud_id)
     headers = {
         "Authorization": f"Bearer {token}",
-        "Accept": "application/json"
+        "Accept": "application/json",
     }
     response = requests.get(
-        f"{JIRA_API_BASE}/search",
+        f"{jira_api_base}/search",
         headers=headers,
         params={
             "jql": jql,
             "maxResults": max_results,
-            "fields": "key,summary,issuetype,fixVersions"
-        }
+            "fields": "key,summary,issuetype,fixVersions",
+        },
     )
     response.raise_for_status()
     return response.json()["issues"]
@@ -29,15 +80,30 @@ def fetch_issues_by_jql(jql, token_file="jira_token.json", max_results=100):
 
 def load_jira_issues(fix_version: str, token_file: str = "jira_token.json") -> dict:
     """Load Jira issues for the given fix version via the Jira Cloud REST API."""
+    issue_types = [
+        "Sub-task",
+        "Tech Story",
+        "Epic",
+        "Test Execution",
+        "Dev Task",
+        "QA Task",
+        "Shoulder Check",
+        "Automation",
+        "Test Plan",
+        "Spike",
+        "Test",
+    ]
+    issue_types = [issue_type.strip() for issue_type in issue_types]
+    excluded_types = ", ".join(f'"{issue_type}"' for issue_type in issue_types)
     jql = (
         f'fixVersion = "{fix_version}" '
-        'AND issuetype not in ('
-        '"Sub-task", "Tech Story", "Epic", "Test Execution", '
-        '"Dev Task", "QA Task", "Shoulder Check", "Automation ", '
-        '"Test Plan", "Spike", "Test")'
+        f"AND issuetype not in ({excluded_types})"
     )
 
     token = get_valid_access_token(token_file)
+    site_url = os.getenv("JIRA_SITE_URL") or os.getenv("JIRA_BASE_URL")
+    cloud_id = resolve_cloud_id(token, site_url=site_url)
+    jira_api_base = build_jira_api_base(cloud_id)
     headers = {
         "Authorization": f"Bearer {token}",
         "Accept": "application/json",
@@ -46,20 +112,40 @@ def load_jira_issues(fix_version: str, token_file: str = "jira_token.json") -> d
     all_issues = []
     start_at = 0
     max_results = 100
-    while True:
-        params = {
-            "jql": jql,
-            "startAt": start_at,
-            "maxResults": max_results,
-            "fields": "summary,issuetype,fixVersions,components,status",
-        }
-        response = requests.get(f"{JIRA_API_BASE}/search", headers=headers, params=params)
-        response.raise_for_status()
-        data = response.json()
-        all_issues.extend(data.get("issues", []))
-        if start_at + max_results >= data.get("total", 0):
+    for attempt in range(2):
+        try:
+            while True:
+                params = {
+                    "jql": jql,
+                    "startAt": start_at,
+                    "maxResults": max_results,
+                    "fields": "summary,issuetype,fixVersions,components,status",
+                }
+                response = requests.get(
+                    f"{jira_api_base}/search", headers=headers, params=params
+                )
+                response.raise_for_status()
+                data = response.json()
+                all_issues.extend(data.get("issues", []))
+                if start_at + max_results >= data.get("total", 0):
+                    break
+                start_at += max_results
             break
-        start_at += max_results
+        except requests.exceptions.HTTPError as exc:
+            status_code = exc.response.status_code if exc.response else None
+            if status_code in (401, 410) and attempt == 0:
+                logger.warning(
+                    "Jira API returned %s. Refreshing token and rediscovering site.",
+                    status_code,
+                )
+                token = get_valid_access_token(token_file, force_refresh=True)
+                headers["Authorization"] = f"Bearer {token}"
+                cloud_id = resolve_cloud_id(token, site_url=site_url)
+                jira_api_base = build_jira_api_base(cloud_id)
+                all_issues = []
+                start_at = 0
+                continue
+            raise
 
     jira_base = os.getenv("JIRA_BASE_URL", "https://csaaig.atlassian.net/browse")
     stories = {}

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Tuple
 from tqdm import tqdm
 
 from config_loader import load_config
-from bitbucket_api import fetch_commits
+from bitbucket_api import fetch_commits, resolve_bitbucket_base_url
 from jira_client import load_jira_issues
 from commit_processor import extract_stories
 from excel_writer import write_excel
@@ -181,6 +181,11 @@ def main() -> None:
     base_url = os.getenv(
         "BITBUCKET_BASE_URL",
         config.get("bitbucket_base_url", "https://bitbucket.example.com/rest/api/1.0"),
+    )
+    base_url = resolve_bitbucket_base_url(
+        base_url,
+        bitbucket_auth=(bitbucket_email, bitbucket_token),
+        bitbucket_headers={"Accept": "application/json"},
     )
     commit_limit = int(config.get("commit_fetch_limit", 100))
     cutoff_days = int(config.get("cutoff_days_before_code_freeze", 28))

--- a/write_jira_token.py
+++ b/write_jira_token.py
@@ -14,8 +14,17 @@ def generate_token(client_id: str, client_secret: str, code: str, redirect_uri: 
         "code": code,
         "redirect_uri": redirect_uri,
     }
-    response = requests.post(TOKEN_URL, json=payload)
-    response.raise_for_status()
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    response = requests.post(TOKEN_URL, data=payload, headers=headers, timeout=30)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as exc:
+        details = response.text.strip()
+        if details:
+            raise requests.exceptions.HTTPError(
+                f"{exc} Response body: {details}", response=response
+            ) from exc
+        raise
     data = response.json()
     data["client_id"] = client_id
     data["client_secret"] = client_secret


### PR DESCRIPTION
### Motivation
- Avoid relying on a hard-coded Jira cloud ID so the tool can work across different Jira Cloud sites.
- Prevent malformed JQL and token-stale failures by normalizing issue-type exclusions and handling expired/invalid tokens.
- Improve connectivity to Bitbucket Server instances by probing likely API base paths when the configured URL is incorrect.

### Description
- Add dynamic Jira discovery using `https://api.atlassian.com/oauth/token/accessible-resources` and derive the API base with `build_jira_api_base(cloud_id)`; implement `_normalize_site_url`, `get_accessible_resources`, and `resolve_cloud_id` in `jira_client.py`.
- Switch `fetch_issues_by_jql` and `load_jira_issues` to resolve the cloud id at runtime (using `JIRA_SITE_URL`/`JIRA_BASE_URL` when present) and normalize the excluded issue types when building the JQL query.
- Add retry logic in `load_jira_issues` to handle `401`/`410` responses by refreshing the token (`get_valid_access_token(..., force_refresh=True)`), rediscovering the site, and retrying the search.
- Add Bitbucket API base probing in `bitbucket_api.py` via `_build_api_base` and `resolve_bitbucket_base_url` which tries `/rest/api/1.0` and `/rest/api/latest` variants and logs which candidate is used.
- Wire `resolve_bitbucket_base_url` into startup in `main.py` so the resolved Bitbucket API base is used for subsequent `fetch_commits` calls.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69823e357b10832fb5aee264c1636a0e)